### PR TITLE
run `contentlayer build` prior to `next build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "contentlayer build && next build",
     "preview": "next build && next start",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
Closes #11. Without this, building in CI environments doesn't work out of the box (i.e. you would need to set a custom Vercel build command `contentlayer build && pnpm build`

More context: see https://github.com/contentlayerdev/website/pull/106, https://github.com/contentlayerdev/website/issues/105